### PR TITLE
added custom xdebug.max_nesting_level to php.ini

### DIFF
--- a/service/php/assets/php.ini
+++ b/service/php/assets/php.ini
@@ -8,3 +8,4 @@ opcache.interned_strings_buffer = 12
 opcache.file_cache = /opcache
 max_execution_time = 3600
 max_input_time = 3600
+xdebug.max_nesting_level = 1000


### PR DESCRIPTION
When working in dev mode of magento 2.4.1 the default xdebug nesting level of 256 seems to be insufficient.